### PR TITLE
Fix upload idempotency replay

### DIFF
--- a/apps/mcp-server/src/mcp/server.ts
+++ b/apps/mcp-server/src/mcp/server.ts
@@ -25,7 +25,7 @@ import { hashIdentifier } from "../observability.js";
 import { hashToken, randomToken } from "../security/crypto.js";
 import type { Repository } from "../storage/repository.js";
 import { WordPressClient } from "../wordpress/client.js";
-import { stableHash } from "../wordpress/payload.js";
+import { stableHash, uploadIdempotencyInput } from "../wordpress/payload.js";
 import { resolveConnectorFile } from "../media/connector-files.js";
 
 const CONSEQUENTIAL_SCOPES: Record<string, Scope> = {
@@ -137,6 +137,14 @@ export class McpService {
           input as Record<string, unknown>,
           context,
         );
+      const wordpressInput =
+        name === "wordpress_upload_media"
+          ? await this.#normalizeUploadInput(
+              connection,
+              input as Record<string, unknown>,
+              context.requestId,
+            )
+          : input;
       const idempotencyKey =
         typeof (input as Record<string, unknown>).idempotencyKey === "string"
           ? (input as Record<string, string>).idempotencyKey
@@ -146,19 +154,15 @@ export class McpService {
           connection.id,
           idempotencyKey,
           name,
-          stableHash(input),
+          stableHash(
+            name === "wordpress_upload_media"
+              ? uploadIdempotencyInput(wordpressInput as Record<string, unknown>)
+              : input,
+          ),
         );
         if (!claim.claimed) return this.#result(claim.response, definition.outputTemplate);
         claimedIdempotency = { connectionId: connection.id, key: idempotencyKey };
       }
-      const wordpressInput =
-        name === "wordpress_upload_media"
-          ? await this.#normalizeUploadInput(
-              connection,
-              input as Record<string, unknown>,
-              context.requestId,
-            )
-          : input;
       const output = await this.#wordpress.call(
         connection,
         name,

--- a/apps/mcp-server/src/wordpress/payload.ts
+++ b/apps/mcp-server/src/wordpress/payload.ts
@@ -20,6 +20,28 @@ export function stableHash(value: unknown): string {
   return createHash("sha256").update(stableJson(value)).digest("base64url");
 }
 
+export function uploadIdempotencyInput(input: Record<string, unknown>): Record<string, unknown> {
+  const file = input.file;
+  if (!file || typeof file !== "object") return input;
+  const resolved = file as Partial<ResolvedConnectorUpload>;
+  if (
+    !(resolved.bytes instanceof Uint8Array) ||
+    typeof resolved.fileName !== "string" ||
+    typeof resolved.mimeType !== "string" ||
+    typeof resolved.sha256 !== "string"
+  ) {
+    return input;
+  }
+  return {
+    ...input,
+    file: {
+      fileName: resolved.fileName,
+      mimeType: resolved.mimeType,
+      sha256: resolved.sha256,
+    },
+  };
+}
+
 function stableJson(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
   if (value && typeof value === "object") {

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -31,23 +31,19 @@ Exact JSON schemas are defined once in `packages/contracts` and referenced by `p
 
 ## Uploading a ChatGPT-generated image
 
-`wordpress_upload_media` declares `file` in `_meta["openai/fileParams"]`. ChatGPT therefore supplies one top-level connector file object; a path string or a `{ "file_id": ... }` partial object is not valid. For an image generated at `/mnt/data/example.png`, the tool-call payload received by the MCP service is:
+`wordpress_upload_media` declares `file` in `_meta["openai/fileParams"]`. In a ChatGPT tool call, pass the generated image's connector-authorized absolute runtime path as the top-level `file` string:
 
 ```json
 {
-  "file": {
-    "download_url": "/mnt/data/example.png",
-    "file_id": "file_<runtime-provided-id>",
-    "mime_type": "image/png",
-    "file_name": "example.png"
-  },
+  "file": "/mnt/data/example.png",
+  "fileName": "example.png",
   "title": "Example image",
   "altText": "Describe the image for screen-reader users",
   "idempotencyKey": "<new-uuid>"
 }
 ```
 
-`download_url` and `file_id` are required; ChatGPT normally fills the complete object when it binds the generated file to the declared `file` parameter. The temporary locator may be an approved HTTPS connector download or a runtime-mounted path. Mounted paths are realpath-checked against `CONNECTOR_UPLOAD_DIRS` (default `/mnt/data`), and the service rejects missing files, symlink escapes, unsafe names, oversized files, MIME/content mismatches, and non-image formats before forwarding a digest-bound multipart upload to WordPress.
+The ChatGPT connector file bridge rewrites that string into the canonical internal connector object containing `download_url`, `file_id`, and optional MIME/name metadata before the MCP validator runs. Callers must not construct that internal object themselves. The temporary locator may resolve to an approved HTTPS connector download or a runtime-mounted path. Mounted paths are realpath-checked against `CONNECTOR_UPLOAD_DIRS` (default `/mnt/data`), and the service rejects missing files, symlink escapes, unsafe names, oversized files, MIME/content mismatches, and non-image formats before forwarding a digest-bound multipart upload to WordPress. Idempotent retries fingerprint the verified content digest, MIME type, safe filename, and user fields rather than the connector's temporary download URL.
 
 For a public remote image, omit `file` and use the separate HTTPS-only form:
 

--- a/tests/unit/connector-files.test.ts
+++ b/tests/unit/connector-files.test.ts
@@ -6,7 +6,11 @@ import {
   resolveConnectorFile,
   type ResolvedConnectorUpload,
 } from "../../apps/mcp-server/src/media/connector-files.js";
-import { stableHash, uploadForm } from "../../apps/mcp-server/src/wordpress/payload.js";
+import {
+  stableHash,
+  uploadForm,
+  uploadIdempotencyInput,
+} from "../../apps/mcp-server/src/wordpress/payload.js";
 
 const PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
@@ -151,5 +155,33 @@ describe("WordPress multipart normalization", () => {
     const second = stableHash({ file: { file_id: "file_2", download_url: "/mnt/data/two.png" } });
     expect(first).toBe(reordered);
     expect(first).not.toBe(second);
+  });
+
+  it("uses verified file content instead of temporary connector references for idempotency", () => {
+    const common = {
+      idempotencyKey: crypto.randomUUID(),
+      altText: "Example",
+    };
+    const resolved = {
+      bytes: new Uint8Array(PNG),
+      fileName: "example.png",
+      mimeType: "image/png" as const,
+      sha256: "a".repeat(64),
+    };
+    const first = stableHash(uploadIdempotencyInput({ ...common, file: resolved }));
+    const retried = stableHash(
+      uploadIdempotencyInput({
+        ...common,
+        file: { ...resolved, bytes: new Uint8Array(PNG) },
+      }),
+    );
+    const changed = stableHash(
+      uploadIdempotencyInput({
+        ...common,
+        file: { ...resolved, sha256: "b".repeat(64) },
+      }),
+    );
+    expect(retried).toBe(first);
+    expect(changed).not.toBe(first);
   });
 });


### PR DESCRIPTION
## What changed

- fingerprints resolved connector uploads by verified SHA-256, MIME type, and safe filename
- excludes temporary connector download references from upload replay identity
- documents the exact ChatGPT-facing local file payload
- adds regression coverage for stable content-based upload idempotency

## Root cause

The MCP service reserved the idempotency key before resolving the connector file. ChatGPT can issue a fresh temporary download reference for the same file on retry, so an identical upload was incorrectly classified as different input.

## Validation

- npm run format:check
- npm run lint
- npm run typecheck
- npm test (57 passed, 12 environment-gated skipped)
- npm run build
- npm run test:security (17 passed)
- npm run package:wordpress
- npm run sbom
- npm run release:reproducible
- npm run release:artifacts
- npm run release:check
- production multipart upload succeeded before this replay correction; replay failure reproduced and isolated