### PR TITLE
fix(security): remediate 10 open Dependabot alerts (3 high)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2126,16 +2126,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -2201,7 +2201,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,23 +13,23 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@cyclonedx/cyclonedx-npm": "*",
-        "@eslint/js": "*",
+        "@cyclonedx/cyclonedx-npm": "latest",
+        "@eslint/js": "latest",
         "@types/cors": "2.8.19",
         "@types/express": "5.0.6",
-        "@types/node": "*",
+        "@types/node": "latest",
         "@types/pg": "8.20.0",
-        "@vitest/coverage-v8": "*",
+        "@vitest/coverage-v8": "latest",
         "archiver": "8.0.0",
-        "concurrently": "*",
-        "eslint": "*",
-        "eslint-plugin-security": "*",
-        "globals": "*",
-        "prettier": "*",
+        "concurrently": "latest",
+        "eslint": "latest",
+        "eslint-plugin-security": "latest",
+        "globals": "latest",
+        "prettier": "latest",
         "tsx": "4.23.1",
-        "typescript": "*",
-        "typescript-eslint": "*",
-        "vitest": "*"
+        "typescript": "latest",
+        "typescript-eslint": "latest",
+        "vitest": "latest"
       },
       "engines": {
         "node": "24.x",
@@ -787,12 +787,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -2270,16 +2270,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -3722,9 +3722,9 @@
       "optional": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3829,9 +3829,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.30",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
-      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3995,9 +3995,9 @@
       "optional": true
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4164,9 +4164,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -6635,9 +6635,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -7725,7 +7725,7 @@
         "zod": "4.4.3"
       },
       "devDependencies": {
-        "typescript": "*"
+        "typescript": "latest"
       }
     },
     "packages/test-fixtures": {
@@ -7733,7 +7733,7 @@
       "version": "1.0.2",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
-        "typescript": "*"
+        "typescript": "latest"
       }
     },
     "packages/tool-schemas": {
@@ -7745,7 +7745,7 @@
         "zod": "4.4.3"
       },
       "devDependencies": {
-        "typescript": "*"
+        "typescript": "latest"
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes the remaining open Dependabot alerts that PRs #35 (wpcs 3.4.1) and #39 (SDK 1.30.0) did **not** cover. Main already carries the SDK pin and wpcs bump; this PR adds the transitive dependency bumps those PRs missed.

## NPM changes (package-lock.json)

- **hono** 4.12.30 → **4.13.1** — fixes GHSA-8j4g-w8fx-2239 (CORS ReDoS), GHSA-54fx-42gc-7vw4 (Language middleware DoS), GHSA-79qm-7rj5-m7r9 (Proxy Helper header leak), GHSA-f23p-vx2j-j53r (`memo()` SSR cross-user disclosure)
- **@hono/node-server** 1.19.14 → **2.1.0** — fixes GHSA-frvp-7c67-39w9 (path traversal via `%5C` on Windows)
- **ip-address** 10.2.0 → **10.4.0** — fixes GHSA-22jq-vg5j-6vgg (IPv4-mapped/NAT64 SSRF bypass), GHSA-4xrf-jv44-h6hh (CIDR suffix SSRF bypass), GHSA-mwp4-54f8-5fhr (leading-zero octal SSRF bypass)
- `npm audit fix` dev-only patches: brace-expansion, js-yaml, tar

## Composer changes (composer.lock)

- **squizlabs/php_codesniffer** 3.13.5 → **3.13.6** — fixes GHSA-hmqg-cxww-wqhq (HIGH, gitblame command injection)

## Verification (local)

- `npm run build:shared` ✅
- `npm run typecheck` ✅
- `npx eslint .` ✅
- `npm test` ✅ 57 passed / 12 skipped (docker-dependent)
- `npm audit` ✅ 0 vulnerabilities (full + `--omit=dev`)
- composer audit ✅ no advisories
- PHP: `php -l` all files ✅, PHPCS ✅, PHPStan ✅, PHPUnit ✅ 3 tests

No direct imports of hono/@hono/node-server in app code — purely transitive through the MCP SDK. SDK 1.30.0 (already on main) permits `@hono/node-server` 2.x, so this resolves cleanly.